### PR TITLE
Add more version support for workflow tests

### DIFF
--- a/.github/workflows/workflow.yml
+++ b/.github/workflows/workflow.yml
@@ -29,6 +29,4 @@ jobs:
          - name: Run unit tests with pytests
            run:  pytest -v --tb=short --color=yes --cov=src --cov-report=term-missing
          - name: Scan for vulnerabilities with Bandit
-           run: |
-            python -m pip install bandit
-            bandit -r src
+           run: bandit -r src

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ pytest
 pytest-cov
 Flask
 flake8
+bandit


### PR DESCRIPTION
Workflow tests will now support ubuntu, mac, and windows operating systems. Additionally, bandit is used for vulnerability testing the code.

I used ChatGPT for this task, and my conversation is linked here:
https://chatgpt.com/share/67060a62-e380-800a-96d3-0f06624d7339